### PR TITLE
[Added] Used webscrollers setting-editor for config edit

### DIFF
--- a/backend/apps/xbin/apis/settings-editor.js
+++ b/backend/apps/xbin/apis/settings-editor.js
@@ -1,0 +1,83 @@
+/**
+ * Settings editor API for XBin. Reads and writes flat JSON/YAML config files.
+ * Registered at /apps/{{app}}/settingseditor in apiregistry.json.
+ * 
+ * Request params:
+ *   op        : "read" or "write"
+ *   conf_file : The xbin path to the (.yaml) file
+ *   extraInfo : Optional extra info for cms.getFullPath (passed through transparently)
+ * 
+ * On read  → returns all top-level keys as a flat object + result:true
+ * On write → merges incoming values over existing config and saves back to disk
+ * 
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+const yaml = require("yaml");
+const fspromises = require("fs").promises;
+const cms = require(`${XBIN_CONSTANTS.LIB_DIR}/cms.js`);
+
+// Keys stripped from incoming write requests — these are request envelope fields,
+// not config values that should ever be persisted.
+const WRITE_STRIP_KEYS = new Set(["op", "path", "conf_file", "encrypted_keys", 
+    "encryption_key", "extraInfo", "result"]);
+
+exports.doService = async (jsonReq, _ignored, headers) => {
+    if (!_validateRequest(jsonReq)) {
+        LOG.error(`settings-editor: Invalid request: ${JSON.stringify(jsonReq)}`);
+        return CONSTANTS.FALSE_RESULT;
+    }
+
+    const filePath = jsonReq.conf_file || jsonReq.path;
+
+    try {
+        const isYaml = filePath.toLowerCase().endsWith(".yaml") || 
+                       filePath.toLowerCase().endsWith(".yml");
+
+        const fullpath = await cms.getFullPath(headers, filePath, jsonReq.extraInfo);
+        if (!fullpath) {
+            LOG.error(`settings-editor: Could not resolve path for: ${filePath}`);
+            return CONSTANTS.FALSE_RESULT;
+        }
+
+        const rawContent = await fspromises.readFile(fullpath, "utf8");
+        const conf = isYaml ? yaml.parse(rawContent) : JSON.parse(rawContent);
+
+        if (!conf || typeof conf !== "object") {
+            LOG.error(`settings-editor: Parsed config is not an object for: ${filePath}`);
+            return CONSTANTS.FALSE_RESULT;
+        }
+
+        if (jsonReq.op === "read") {
+            return { ...conf, ...CONSTANTS.TRUE_RESULT };
+        }
+
+        if (jsonReq.op === "write") {
+            const incomingValues = {};
+            for (const [key, value] of Object.entries(jsonReq))
+                if (!WRITE_STRIP_KEYS.has(key)) incomingValues[key] = value;
+
+            const newConf = { ...conf, ...incomingValues };
+
+            const newConfRaw = isYaml
+                ? yaml.stringify(newConf, { lineWidth: 0 })
+                : JSON.stringify(newConf, null, 4);
+
+            await fspromises.writeFile(fullpath, newConfRaw, "utf8");
+            LOG.info(`settings-editor: Successfully wrote config to: ${filePath}`);
+            return CONSTANTS.TRUE_RESULT;
+        }
+
+        return CONSTANTS.FALSE_RESULT;
+
+    } catch (err) {
+        LOG.error(`settings-editor: Error on op=${jsonReq.op} path=${filePath}: ${err.message}\n${err.stack}`);
+        return CONSTANTS.FALSE_RESULT;
+    }
+};
+
+const _validateRequest = jsonReq =>
+    jsonReq &&
+    (jsonReq.op === "read" || jsonReq.op === "write") &&
+    (jsonReq.conf_file || jsonReq.path);

--- a/backend/apps/xbin/conf/apiregistry.json
+++ b/backend/apps/xbin/conf/apiregistry.json
@@ -15,6 +15,7 @@
     "/apps/{{app}}/proxiedapis/downloaddnd" : "/apis/downloaddnd.js?get=true",
     "/apps/{{app}}/getdownloadstatus" : "/apis/getdownloadstatus.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=user,admin",
     "/apps/{{app}}/checkquota" : "/apis/checkquota.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=user,admin",
+    "/apps/{{app}}/settingseditor": "/apis/settings-editor.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=user,admin",
 
     "/apps/{{app}}/log" : "{{server_lib}}/log.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&logpath={{server}}/../apps/{{app}}/logs/remotelog.ndjson",
     "/apps/{{app}}/getremotelog" : "/apis/getremotelog.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389",

--- a/frontend/apps/xbin/components/file-manager/file-manager.html
+++ b/frontend/apps/xbin/components/file-manager/file-manager.html
@@ -186,6 +186,46 @@ div#informationbox textarea#filecomments, div#informationbox textarea#filecommen
 }
 div#informationbox.visible {display: flex !important;}
 
+/* AI App Editor Box */
+
+div#aiappeditorbox {
+    height: calc(100% - 2px - 4em);
+    width: 50%;
+    border: 1px solid;
+    border-radius: 1em;
+    color: inherit;
+    padding: 2em;
+    box-sizing: border-box;
+    display: none;
+    flex-direction: column;
+    overflow: auto;
+    z-index: 2;
+    background-color: #ffffff;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 4px 32px rgba(0,0,0,0.18);
+}
+div#aiappeditorbox.visible { display: flex !important; }
+div#aiappeditorbox > div#aiappeditoractions {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 1em;
+    margin-top: 1em;
+    flex-shrink: 0;
+}
+@container (max-width:960px) {
+    div#aiappeditorbox {
+        width: 95%;
+        height: 90%;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
+}
+
 div#contextmenu {
     display: none;
     flex-direction: column;
@@ -408,6 +448,20 @@ span.button {
 </div>
 
 <div id="informationbox" onclick="event.stopImmediatePropagation()">
+</div>
+
+<div id="aiappeditorbox" onclick="event.stopImmediatePropagation()">
+    <settings-editor id="aiappeditor"></settings-editor>
+    <div id="aiappeditoractions">
+        <span class="button" onclick='event.stopPropagation(); 
+            monkshu_env.components["file-manager"].closeAIAppEditor(this)'>
+            Cancel
+        </span>
+        <span class="button" onclick='event.stopPropagation(); 
+            monkshu_env.components["file-manager"].saveAIApp(this)'>
+            Save
+        </span>
+    </div>
 </div>
 
 <div id="notificationscrollpositioner">

--- a/frontend/apps/xbin/components/file-manager/file-manager.mjs
+++ b/frontend/apps/xbin/components/file-manager/file-manager.mjs
@@ -36,6 +36,7 @@ const API_CHECKFILEEXISTS = _ => API_PATH+"/checkfileexists";
 const API_DOWNLOADFILE_GETSECURID = _ => API_PATH+"/getsecurid";
 const API_DOWNLOADFILE_STATUS = _ => API_PATH+"/getdownloadstatus";
 const API_DOWNLOADFILE_DND = _ => APP_PATH+"/proxiedapis/downloaddnd";
+const API_SETTINGSEDITOR = _ => API_PATH+"/settingseditor";
 let PAGE_DOWNLOADFILE_SHARED = COMPONENT_PATH+"/downloadshared.html", ENCODE_URL = true;
 const LOG = $$.LOG;
 
@@ -43,6 +44,7 @@ const DIALOG_SCROLL_ELEMENT_ID = "notificationscrollpositioner", DIALOG_HOST_ELE
    PROGRESS_TEMPLATE="progressdialog", DEFAULT_SHARE_EXPIRY = 5;
 const DOUBLE_CLICK_DELAY=400, DOWNLOADFILE_REFRESH_INTERVAL = 1000, UPLOAD_ICON = "⇧", DOWNLOAD_ICON = "⇩",
    DOWNLOAD_FILE_OP = "DOWNLOAD_DIRECTION", UPLOAD_FILE_OP = "UPLOAD_DIRECTION", FMDIALOG_ID = "fmdialog";
+const XBIN_FILE_OPEN_EVENT = "xbin_file_open";
 const dialog = element => {
    const orgDialog = monkshu_env.components['dialog-box'];
    const host = element ? file_manager.getHostElement(element) : undefined;
@@ -120,6 +122,8 @@ async function elementConnected(host) {
    file_manager.setData(host.id, data);
 
    if (host.getAttribute("downloadpage")) PAGE_DOWNLOADFILE_SHARED = host.getAttribute("downloadpage");
+   blackboard.registerListener(XBIN_FILE_OPEN_EVENT, eventData => 
+      _openIfAIApp(eventData.path, eventData.element));
 }
 
 function _getIconForEntry(entry) {
@@ -423,9 +427,14 @@ async function editFile(element) {
 
    if (selectedElement.id == "paste") {paste(selectedElement); return;}
 
-   if (!selectedElement.dataset.stats) _showErrordialog();  // not a file, not sure 
-   else if (JSON.parse(selectedElement.dataset.stats).size < MAX_EDIT_SIZE) editFileLoadData(element);  // now it can only be a file 
-   else _showErrorDialog(null, await i18n.get("FileTooBigToEdit"));  // too big to edit inline - download and edit
+   if (_isAIAppEditableFile(selectedPath)) {
+      await _openAIAppEditor(element);
+      return;
+   }
+
+   if (!selectedElement.dataset.stats) _showErrordialog();
+   else if (JSON.parse(selectedElement.dataset.stats).size < MAX_EDIT_SIZE) editFileLoadData(element);
+   else _showErrorDialog(null, await i18n.get("FileTooBigToEdit"));
 }
 
 async function editFileLoadData(element) {
@@ -439,6 +448,56 @@ async function editFileLoadData(element) {
          data: result.filecontents}, element), true);
       if (!resp.result) _showErrordialog();
    }); else _showErrordialog();
+}
+
+async function _openAIAppEditor(element) {
+    const shadowRoot = file_manager.getShadowRootByContainedElement(element),
+        editorBox = shadowRoot.querySelector("div#aiappeditorbox"),
+        informationBox = shadowRoot.querySelector("div#informationbox"),
+        editorComponent = shadowRoot.querySelector("settings-editor#aiappeditor");
+    if ((!editorBox) || (!editorComponent)) {_showErrorDialog(null, "AI app editor is not available."); return false;}
+
+    const newEditor = document.createElement("settings-editor");
+    newEditor.id = "aiappeditor";
+    newEditor.setAttribute("apiurl", API_SETTINGSEDITOR());
+    newEditor.setAttribute("conffile", selectedPath);
+
+    const encryptedKeys = _getHostAttribute(element, "settingseditor-encryptedkeys"),
+        encryptionKey = _getHostAttribute(element, "settingseditor-encryptionkey");
+    if (encryptedKeys) newEditor.setAttribute("encryptedkeys", encryptedKeys);
+    if (encryptionKey) newEditor.setAttribute("encryptionkey", encryptionKey);
+
+    editorComponent.replaceWith(newEditor);
+    informationBox?.classList.remove("visible");
+    editorBox.classList.add("visible");
+    return true;
+}
+
+function closeAIAppEditor(element) {
+    const shadowRoot = file_manager.getShadowRootByContainedElement(element);
+    shadowRoot.querySelector("div#aiappeditorbox")?.classList.remove("visible");
+}
+
+async function saveAIApp(element) {
+    const saved = await monkshu_env.components["settings-editor"].update("aiappeditor");
+    if (saved) closeAIAppEditor(element);
+    else _showErrorDialog(null, "Save failed. Please check values and try again.");
+}
+
+function _openIfAIApp(path, element) {
+   const eventPath = path?.replace(/[\/]+/g,"/");
+   if ((!eventPath) || (!_isAIAppEditableFile(eventPath))) return false;
+
+   selectedPath = eventPath; selectedElement = element || selectedElement;
+   if (!selectedElement) return false;
+
+   _openAIAppEditor(selectedElement);
+   return true;
+}
+
+const _isAIAppEditableFile = path => {
+   const lowerPath = path?.toLowerCase(); if (!lowerPath) return false;
+   return lowerPath.endsWith(".yaml") || lowerPath.endsWith(".yml") || lowerPath.endsWith(".json");
 }
 
 function editFileVisible() {
@@ -683,5 +742,5 @@ const _getHostAttribute = (hostOrElement, attributeName) => {
 export const file_manager = { trueWebComponentMode: true, elementConnected, elementRendered, handleClick, 
    showMenu, deleteFile, editFile, downloadFile, cut, copy, paste, upload, uploadFiles, create, shareFile, 
    renameFile, menuEventDispatcher, isMobile, getDragAndDropDownloadURL, showDownloadProgress, hideNotification,
-   cancelFile, editFileVisible, showHideNotifications, getInfoOnFile, updateFileEntryCommentIfModified, changeToPath }
+   cancelFile, editFileVisible, showHideNotifications, getInfoOnFile, updateFileEntryCommentIfModified, changeToPath , closeAIAppEditor, saveAIApp}
 monkshu_component.register("file-manager", `${COMPONENT_PATH}/file-manager.html`, file_manager);

--- a/frontend/apps/xbin/components/settings-editor/settings-editor.html
+++ b/frontend/apps/xbin/components/settings-editor/settings-editor.html
@@ -1,0 +1,51 @@
+<!--
+/* 
+* (C) 2026 TekMonks. All rights reserved.
+* License: See enclosed LICENSE file.
+*/
+-->
+<style>
+body {margin: 0;}
+div#settings {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+div.settingsfields {
+    display: flex;
+    flex-direction: row;
+    padding: 1em 0em;
+    align-items: self-start;
+}
+span.fieldname {width: 20em;}
+span.fieldvalue {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+}
+input.fieldinput, textarea.fieldinput {
+    width: calc(100% - 0.9rem);
+    padding: 0.5em;
+    border-radius: 0.5em;
+    border: 0;
+    outline: none;
+    resize: none;
+    background-color: #D9D9D9;
+    font-family: inherit;
+}
+textarea.fieldinput {height: 8em;}
+</style>
+
+<div id="settings">
+    {{#schema}}
+    <div class="settingsfields">
+        <span class="fieldname" id="spanname{{{key}}}">{{name}}</span>
+        <span class="fieldvalue">
+            {{^textarea}}<input id="value{{{key}}}" class="fieldinput" value="{{value}}" 
+                placeholder="Value for {{name}}"/>{{/textarea}}
+            {{#textarea}}<textarea id="value{{{key}}}" class="fieldinput" 
+                placeholder="Value for {{name}}">{{value}}</textarea>{{/textarea}}
+        </span>
+    </div>
+    {{/schema}}
+</div>

--- a/frontend/apps/xbin/components/settings-editor/settings-editor.mjs
+++ b/frontend/apps/xbin/components/settings-editor/settings-editor.mjs
@@ -1,0 +1,152 @@
+/** 
+ * Settings editor component. Renders a YAML or JSON config file as an editable
+ * form. Each top-level key becomes an input (short values) or textarea (long
+ * values, objects, arrays). On save the values are written back via the backend
+ * API preserving the original file type.
+ * 
+ * HTML attributes:
+ *   apiurl        : URL of the settings-editor backend API
+ *   conffile      : xbin path to the config file to edit
+ *   encryptedkeys : comma-separated list of keys whose values are encrypted (optional)
+ *   encryptionkey : name of the key that holds the encryption key (optional)
+ * 
+ * (C) 2026 TekMonks. All rights reserved.
+ * License: See enclosed LICENSE file.
+ */
+
+import {util} from "/framework/js/util.mjs";
+import {apimanager as apiman} from "/framework/js/apimanager.mjs";
+import {monkshu_component} from "/framework/js/monkshu_component.mjs";
+
+const COMPONENT_PATH = util.getModulePath(import.meta);
+
+async function elementConnected(host) {
+    const apiurl = host.getAttribute("apiurl");
+    const conf_file = host.getAttribute("conffile");
+
+    if (!apiurl || !conf_file) return;
+
+    const encrypted_keys = host.getAttribute("encryptedkeys")
+        ? host.getAttribute("encryptedkeys").split(",") 
+        : undefined;
+    const encryption_key = host.getAttribute("encryptionkey");
+
+    const currentConfig = await apiman.rest(apiurl, "POST",
+        {conf_file, encrypted_keys, encryption_key, op: "read"}, true);
+
+    if (!currentConfig?.result) {
+        LOG.error(`settings-editor: Failed to read config: ${conf_file}`);
+        return;
+    }
+
+    const schema = [];
+    for (const [key, value] of Object.entries(currentConfig)) {
+        if (key === "result") continue;
+
+        const keyName = key.split(/[-_]+/)
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ");
+
+        const valueType = _getValueType(value);
+        const valueStr  = _getStringValue(value, valueType);
+        const fieldType = _getFieldType(valueType, valueStr);
+
+        schema.push({
+            name: keyName, key, type: fieldType,
+            value: valueStr, valueType,
+            textarea: fieldType === "textarea" ? true : undefined
+        });
+    }
+
+    const memory = settings_editor.getMemoryByHost(host);
+    memory.current_schema  = schema;
+    memory.apiurl          = apiurl;
+    memory.conf_file       = conf_file;
+    memory.encrypted_keys  = encrypted_keys;
+    memory.encryption_key  = encryption_key;
+
+    settings_editor.setData(host.id, {schema});
+}
+
+async function update(hostid) {
+    const shadowRoot = settings_editor.getShadowRootByHostId(hostid);
+    const memory     = settings_editor.getMemory(hostid);
+
+    if (!shadowRoot || !memory?.apiurl || !memory?.conf_file) {
+        LOG.error(`settings-editor: update() called but component is not ready (hostid=${hostid})`);
+        return false;
+    }
+
+    const config = {};
+    for (const schemaEntry of memory.current_schema || []) {
+        const el  = shadowRoot.querySelector(`#value${schemaEntry.key}`);
+        const raw = el ? el.value.trim().replace(/\r\n/g, "\n") : schemaEntry.value;
+
+        try {
+            config[schemaEntry.key] = _getTypedValue(raw, schemaEntry);
+        } catch (err) {
+            LOG.error(`settings-editor: Validation error on field "${schemaEntry.key}": ${err.message}`);
+            return false;
+        }
+    }
+
+    const result = await apiman.rest(memory.apiurl, "POST", {
+        conf_file:      memory.conf_file,
+        encrypted_keys: memory.encrypted_keys,
+        encryption_key: memory.encryption_key,
+        op:             "write",
+        ...config
+    }, true);
+
+    if (!result?.result) {
+        LOG.error(`settings-editor: Backend write failed for: ${memory.conf_file}`);
+        return false;
+    }
+
+    return true;
+}
+
+function _getValueType(value) {
+    if (value === undefined) return "undefined";
+    if (value === null)      return "null";
+    if (Array.isArray(value)) return "array";
+    return typeof value;
+}
+
+function _getStringValue(value, valueType) {
+    if (valueType === "undefined" || valueType === "null") return "";
+    if (valueType === "array" || valueType === "object")
+        return JSON.stringify(value, null, 4);
+    return String(value);
+}
+
+function _getFieldType(valueType, valueStr) {
+    if (valueType === "array" || valueType === "object") return "textarea";
+    return valueStr.length > 50 ? "textarea" : "input";
+}
+
+function _getTypedValue(raw, schemaEntry) {
+    switch (schemaEntry.valueType) {
+        case "number": {
+            if (raw === "") return null;
+            const n = Number(raw);
+            if (Number.isNaN(n)) throw new Error(`"${schemaEntry.name}" must be a number.`);
+            return n;
+        }
+        case "boolean":
+            return raw.toLowerCase() === "true";
+        case "null":
+            return raw === "" ? null : raw;
+        case "array":
+        case "object": {
+            if (!raw) return schemaEntry.valueType === "array" ? [] : {};
+            try       { return JSON.parse(raw); }
+            catch (e) { throw new Error(`"${schemaEntry.name}" contains invalid JSON: ${e.message}`); }
+        }
+        default:
+            return raw;
+    }
+}
+
+export const settings_editor = {trueWebComponentMode: true, elementConnected, update};
+monkshu_component.register("settings-editor", `${COMPONENT_PATH}/settings-editor.html`, settings_editor);

--- a/frontend/apps/xbin/main.html
+++ b/frontend/apps/xbin/main.html
@@ -156,6 +156,7 @@ file-manager#fm {height: 100%;}
 	import "./components/span-with-menu/span-with-menu.mjs";
 	import "./components/file-manager/file-manager.mjs";
 	import "./components/progress-bar/progress-bar.mjs";
+	import "./components/settings-editor/settings-editor.mjs";
 	import {blackboard} from "/framework/js/blackboard.mjs";
 	import {monkshu_component} from "/framework/js/monkshu_component.mjs";
 	blackboard.registerListener(monkshu_component.BLACKBOARD_MESSAGE_COMPONENT_RENDERED, component => {


### PR DESCRIPTION
**Summary**

Integrated the settings-editor web component into XBin file manager. Now when a user double-clicks any .yaml or .yml file, instead of a raw textarea editor, a structured field-by-field editor opens that renders each key of the YAML as a proper input or textarea. The user can edit values and save them back to disk.

**What Changed**

- Added settings-editor component (frontend + backend) from webscrolls2 into XBin
- Registered new /apps/{{app}}/settingseditor backend API in apiregistry.json
- Modified file-manager.mjs to intercept .yaml/.yml files and open the new editor instead of raw textarea
- Added div#aiappeditorbox in file-manager.html as a centered modal panel
- Imported settings-editor component in main.html

**Testing Done**

- Multiple YAML files opened and edited correctly
- Save and Cancel both working

**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6325

<img width="1827" height="943" alt="Screenshot from 2026-03-17 16-35-58" src="https://github.com/user-attachments/assets/790b1122-006e-468c-be37-a6ddabf5073f" />
