### PR TITLE
[FIX] delete share link on clicking cancel button

### DIFF
--- a/backend/apps/xbin/apis/sharefile.js
+++ b/backend/apps/xbin/apis/sharefile.js
@@ -36,4 +36,4 @@ async function deleteSharesForID(id) {
 	return await db.runTransaction(deleteDrops);
 }
 
-const validateRequest = jsonReq => (jsonReq && (jsonReq.path || (jsonReq.id && jsonReq.expiry)));
+const validateRequest = jsonReq => (jsonReq && (jsonReq.path || (jsonReq.id && jsonReq.expiry != null)));


### PR DESCRIPTION
**What changed**
- Fixed `validateRequest` in `sharefile.js` — changed expiry truthy check to `!= null`

**Why changed**
- `expiry=0` (sent on cancel) was falsy in JS, so validation failed and share was never deleted from DB
- Cancelled share links remained accessible until original expiry

**Result**
- Cancel button now correctly deletes the share immediately
- Link returns Bad link message right after cancel

**Testing Done**
- Shared a file → clicked Cancel → verified share was deleted from DB
- Opened the cancelled link → got Error: Bad link , file not accessible

**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6364