### PR TITLE
[Feature] Added minute and hour duration options for file sharing

### DIFF
--- a/backend/apps/xbin/apis/sharefile.js
+++ b/backend/apps/xbin/apis/sharefile.js
@@ -17,12 +17,12 @@ exports.doService = async (jsonReq, _, headers) => {
 			if (!await cms.isSecure(headers, fullpath, jsonReq.extraInfo)) {LOG.error(`Path security validation failure: ${jsonReq.path}`); return CONSTANTS.FALSE_RESULT;}
 			if (!await uploadfile.isFileConsistentOnDisk(fullpath)) {LOG.error(`Path is not consistent on the disk ${jsonReq.path}`); return CONSTANTS.FALSE_RESULT;}
 
-			const expiry = Date.now()+((jsonReq.expiry||XBIN_CONSTANTS.CONF.DEFAULT_SHARED_FILE_EXPIRY)*86400000);	
+			const expiry = Date.now()+_getExpiryMillis(jsonReq.expiry||XBIN_CONSTANTS.CONF.DEFAULT_SHARED_FILE_EXPIRY, jsonReq.expiry_unit||"days");
 			const id = crypto.createHash("sha512").update(fullpath+expiry+(Math.random()*(1000000 - 1)+1)).digest("hex");
 			await db.runCmd("INSERT INTO shares(fullpath, id, expiry) VALUES (?,?,?)", [fullpath,id,expiry]);
 			return {result: true, id};
 		} else {	// update expiry
-			if (jsonReq.expiry != 0) await db.runCmd("UPDATE shares SET expiry = ? WHERE id = ?", [Date.now()+(jsonReq.expiry*86400000),jsonReq.id]);
+			if (jsonReq.expiry != 0) await db.runCmd("UPDATE shares SET expiry = ? WHERE id = ?", [Date.now()+_getExpiryMillis(jsonReq.expiry, jsonReq.expiry_unit||"days"),jsonReq.id]);
 			else await db.runCmd("DELETE FROM shares WHERE id = ?", [jsonReq.id]);
 			return {result: true, id: jsonReq.id};
 		}
@@ -34,6 +34,13 @@ async function deleteSharesForID(id) {
 		{cmd:"DELETE FROM quotas WHERE id = ?", params: [id]}];
 
 	return await db.runTransaction(deleteDrops);
+}
+
+const _getExpiryMillis = (value, unit="days") => {
+	const n = Number(value), unitNormalized = unit.toLowerCase();
+	if (unitNormalized == "minutes") return n * 60000;
+	if (unitNormalized == "hours") return n * 3600000;
+	return n * 86400000;
 }
 
 const validateRequest = jsonReq => (jsonReq && (jsonReq.path || (jsonReq.id && jsonReq.expiry)));

--- a/frontend/apps/xbin/components/file-manager/dialogs/sharefile.html
+++ b/frontend/apps/xbin/components/file-manager/dialogs/sharefile.html
@@ -36,13 +36,56 @@ span#expiryspan {
     font-size: smaller;
     margin-bottom: 20px;
     padding-left: 2px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 6px;
 }
 
-span#expiryspan > input#expiry {
-    width: 2.5em;
-    border-style: none;
+span#expirycontrols {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    padding: 0.85em 1em;
+    border-radius: 10px;
+    background-color: #F0F8FF;
+    box-shadow: 0 0 0px 1000px #F0F8FF inset;
+    color: #4788C7;
+}
+
+span#expirycontrols > span {
+    font-weight: 500;
+}
+
+span#expirycontrols > input#expiry_value {
+    width: 4.2em;
+    border: 1px solid rgba(71, 136, 199, 0.28);
+    border-radius: 10px;
     outline: none;
     font-family: 'Serif';
+    text-align: center;
+    padding: 0.45em 0.4em;
+    background: #ffffff;
+    color: #4788C7;
+    box-sizing: border-box;
+}
+
+span#expirycontrols > select#expiry_unit {
+    border: 1px solid rgba(71, 136, 199, 0.28);
+    border-radius: 10px;
+    outline: none;
+    font-family: 'Serif';
+    background: #ffffff;
+    cursor: pointer;
+    color: #4788C7;
+    padding: 0.45em 0.7em;
+    min-width: 7.5em;
+    box-sizing: border-box;
+}
+
+@media (max-width: 900px) {
+body {width: auto}
 }
 
 span#copied {
@@ -63,6 +106,16 @@ span#copied {
         selector.querySelector('span#copied').style.opacity=1;
         setTimeout(_=>selector.querySelector('span#copied').style.opacity=0, 1300);" src="{{dialogpath}}/img/copy.svg">
 </span>
-<span id="expiryspan">Share for <input id="expiry" type="number" value="{{shareDuration}}" min="1" onkeyup="if (this.value<0) this.value=this.value*-1;"> days</span>
+<span id="expiryspan">
+    <span id="expirycontrols">
+        <span>Share for</span>
+        <input id="expiry_value" type="number" value="{{shareDuration}}" min="1" step="1" inputmode="numeric" oninput="if (this.value && this.value < 1) this.value = 1;">
+        <select id="expiry_unit">
+        <option value="minutes" {{minutesSelected}}>Minutes</option>
+        <option value="hours"   {{hoursSelected}}>Hours</option>
+        <option value="days"    {{daysSelected}}>Days</option>
+        </select>
+    </span>
+</span>
 <span id="copied">{{i18n.Copied}}</span>
 </div>

--- a/frontend/apps/xbin/components/file-manager/file-manager.mjs
+++ b/frontend/apps/xbin/components/file-manager/file-manager.mjs
@@ -40,7 +40,7 @@ let PAGE_DOWNLOADFILE_SHARED = COMPONENT_PATH+"/downloadshared.html", ENCODE_URL
 const LOG = $$.LOG;
 
 const DIALOG_SCROLL_ELEMENT_ID = "notificationscrollpositioner", DIALOG_HOST_ELEMENT_ID = "notification", 
-   PROGRESS_TEMPLATE="progressdialog", DEFAULT_SHARE_EXPIRY = 5;
+   PROGRESS_TEMPLATE="progressdialog", DEFAULT_SHARE_EXPIRY = 5 , DEFAULT_SHARE_EXPIRY_UNIT = "days";
 const DOUBLE_CLICK_DELAY=400, DOWNLOADFILE_REFRESH_INTERVAL = 1000, UPLOAD_ICON = "⇧", DOWNLOAD_ICON = "⇩",
    DOWNLOAD_FILE_OP = "DOWNLOAD_DIRECTION", UPLOAD_FILE_OP = "UPLOAD_DIRECTION", FMDIALOG_ID = "fmdialog";
 const dialog = element => {
@@ -574,16 +574,22 @@ function renameFile(element) {
 
 async function shareFile(element) {
    const paths = selectedPath.split("/"), name = paths[paths.length-1];
-   const resp = await apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo({path: selectedPath, expiry: SHARE_DURATION}, element), true);
+   const resp = await apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo({path: selectedPath, expiry: SHARE_DURATION, expiry_unit: DEFAULT_SHARE_EXPIRY_UNIT}, element), true);
    const downloadlink = resp?`${PAGE_DOWNLOADFILE_SHARED}?id=${resp.id}&name=${name}&apipath=${API_PATH}`:null;
    if (!resp || !resp.result) _showErrorDialog(); else dialog(element).showDialog( 
       `${DIALOGS_PATH}/sharefile.html`, true, true, 
       { link: ENCODE_URL ? router.encodeURL(downloadlink):downloadlink, id: resp.id, 
-         shareDuration: SHARE_DURATION, dialogpath: DIALOGS_PATH }, 
-      FMDIALOG_ID, ["expiry"], async result => {   // on OK clicked, next param is for cancel clicked
+         shareDuration: SHARE_DURATION, minutesSelected: "", hoursSelected: "", daysSelected: "selected", dialogpath: DIALOGS_PATH }, 
+      FMDIALOG_ID, ["expiry_value", "expiry_unit"], async result => {
          dialog(element).hideDialog(FMDIALOG_ID); 
-         if (result.expiry != SHARE_DURATION) apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo(
-            {id: resp.id, expiry: result.expiry}, element), true); 
+         const value = Number(result.expiry_value), unit = result.expiry_unit || DEFAULT_SHARE_EXPIRY_UNIT;
+         if (!Number.isInteger(value) || value < 1) {
+            _showErrorDialog(null, "Share duration must be at least 1.");
+            await apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo({id: resp.id, expiry: 0}, element), true);
+            return;
+         }
+         if ((value != SHARE_DURATION) || (unit != DEFAULT_SHARE_EXPIRY_UNIT)) await apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo(
+            {id: resp.id, expiry: value, expiry_unit: unit}, element), true); 
       }, async _ => apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo({id: resp.id, expiry: 0}, element), true) 
    );
 }


### PR DESCRIPTION
**What Changed**

- Added _getExpiryMillis() helper in sharefile.js — converts expiry value to milliseconds based on unit (minutes/hours/days)
- Both create and update share flows now use unit-aware expiry calculation
- Added DEFAULT_SHARE_EXPIRY_UNIT constant in file-manager.mjs
- Share create API call now sends expiry_unit along with expiry
- Dialog now collects two fields — expiry_value and expiry_unit — instead of just expiry
- Added frontend validation — value must be a positive integer, invalid input deletes the pending share
- Updated sharefile.html — replaced plain days input with a grouped number input + unit dropdown (Minutes / Hours / Days)

**Why Changed**

- Earlier system only supported days as expiry unit, minimum being 1 day
- No way to share a file for a few hours or minutes
- Reduces risk of oversharing — user can now limit access to exact hours/minutes needed
- QA team needed short-lived shares for testing expiry behaviour without waiting full days

**Testing Done**

- Shared file with 2 minutes → link expired in exactly 2 minutes
- Shared file with 1 hour → link expired in exactly 1 hour

<img width="1828" height="920" alt="Screenshot from 2026-03-23 16-48-01" src="https://github.com/user-attachments/assets/e6ee9ee4-5f70-4ff2-b8a8-1a18bc94af90" />


**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6365