### PR TITLE
[FIX] Paste button icon is visible

### DIFF
--- a/frontend/apps/xbin/components/file-manager/file-manager.mjs
+++ b/frontend/apps/xbin/components/file-manager/file-manager.mjs
@@ -473,10 +473,10 @@ function getDragAndDropDownloadURL(path, element) {
 const showDownloadProgress = (path, element) => _showDownloadProgress(element, path, element["data-reqid"]);
 
 function cut(element) { selectedCutPath = selectedPath; selectedCutCopyElement = selectedElement.cloneNode(); 
-   file_manager.reload(file_manager.getHostElementID(element)); }
+   router.reload(!ENCODE_URL, false); }
 
 function copy(element) { selectedCopyPath = selectedPath; selectedCutCopyElement = selectedElement.cloneNode(); 
-   file_manager.reload(file_manager.getHostElementID(element)); }
+   router.reload(!ENCODE_URL, false); }
 
 async function paste(element) {
    const _copyRequestedToItsOwnSubdirectory = (from, to) => {const pathSplits = to.split("/");


### PR DESCRIPTION
**Root Cause:**
- cut() and copy() were using file_manager.reload(), which performs a component-level rerender through Monkshu’s component framework.
- In this rerender path, inline SVG icons using fill="currentColor" were not rendering reliably, causing the Paste action to appear without its icon immediately after Cut/Copy.
- Folder navigation did not show the same issue because changeToPath() already uses router.reload(), which rebuilds the page through Monkshu’s router and renders the icons correctly.

**What Changed:**
- Replaced file_manager.reload() with router.reload(!ENCODE_URL, false) in cut() and copy().
- This matches the existing changeToPath() pattern already used in the same component.

**Why Changed:**

- After Cut/Copy on the root directory, the Paste action appeared but its icon did not render immediately.
- file_manager.reload() uses a component-level rerender path where currentColor-based inline SVGs were not rendering reliably in this flow.
- router.reload() rebuilds the page through the router, which renders the icons correctly.
- This keeps the behavior consistent with the existing navigation path in the same file.

**Testing Done**
- Cut/Copy on root → Paste icon renders correctly
- Paste moves/copies file successfully 
- Cut/Copy in subfolders - behaviour unchanged
- No regressions observed

Mantis Link:  https://tekmonks.mantishub.io/app/issues/6368

Previous:
<img width="1819" height="904" alt="Screenshot from 2026-03-24 23-39-03" src="https://github.com/user-attachments/assets/093476f0-2237-43bd-a84b-350cf2606a5d" />
After Fix:
<img width="1023" height="398" alt="Screenshot from 2026-03-24 23-39-57" src="https://github.com/user-attachments/assets/45e53908-7480-4253-af8c-2f838886d517" />

