### PR TITLE
[FIX] Shared link generation for filenames with special characters

### DIFF
--- a/frontend/apps/xbin/components/file-manager/file-manager.mjs
+++ b/frontend/apps/xbin/components/file-manager/file-manager.mjs
@@ -575,7 +575,7 @@ function renameFile(element) {
 async function shareFile(element) {
    const paths = selectedPath.split("/"), name = paths[paths.length-1];
    const resp = await apiman.rest(API_SHAREFILE(), "GET", _addExtraInfo({path: selectedPath, expiry: SHARE_DURATION, expiry_unit: DEFAULT_SHARE_EXPIRY_UNIT}, element), true);
-   const downloadlink = resp?`${PAGE_DOWNLOADFILE_SHARED}?id=${resp.id}&name=${name}&apipath=${API_PATH}`:null;
+   const downloadlink = resp?`${PAGE_DOWNLOADFILE_SHARED}?${new URLSearchParams({id: resp.id, name, apipath: API_PATH}).toString()}`:null;
    if (!resp || !resp.result) _showErrorDialog(); else dialog(element).showDialog( 
       `${DIALOGS_PATH}/sharefile.html`, true, true, 
       { link: ENCODE_URL ? router.encodeURL(downloadlink):downloadlink, id: resp.id, 


### PR DESCRIPTION
**Root Cause:**

- In file-manager.mjs, the share download link was built using raw string concatenation , name param was inserted directly without URL encoding
- When a filename contained reserved URL characters such as #, the browser treated part of the filename as a fragment, so the full filename did not reach the server.
- In checkshare.js, the decoded filename from the request was compared with the actual filename from DB, so this mismatch caused shared link validation to fail.

**What Changed:**

- Replaced raw string concatenation with URLSearchParams in shareFile() for building the share download link
- All query params (id, name, apipath) are now safely encoded before being added to the URL

**Why Changed:**

- Files with special characters in their names could generate broken shared links.
- URLSearchParams safely handles reserved URL characters and makes link generation reliable.
- This keeps the URL building consistent and safe for any filename

**Testing Done:**
- Shared file with special chars (@#$%&) in name - link opens correctly
- checkshare receives full correct filename, comparison passes
- Share works as expected for normal filenames too - no regression

**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6375

**Previous:**
<img width="1821" height="904" alt="Screenshot from 2026-03-25 16-06-11" src="https://github.com/user-attachments/assets/8448bf18-fe2d-4ce4-bd1b-3a8ce4a7eb5f" />

**After Fix:**
<img width="1821" height="904" alt="Screenshot from 2026-03-25 16-24-21" src="https://github.com/user-attachments/assets/0ae64e34-eee9-4c25-8d1f-ce7daf4f9dca" />
