### PR TITLE
[FIX] Get Info created and modified timestamps

### DIFF
--- a/backend/apps/xbin/apis/uploadfile.js
+++ b/backend/apps/xbin/apis/uploadfile.js
@@ -165,9 +165,9 @@ exports.updateFileStats = async function (fullpathOrRequestHeaders, remotepath, 
 	if (commentin) clusterMemory.files_stats[fullpath].comment = commentin;
 
 	if (transferFinished) {
-		if (!clusterMemory.files_stats[fullpath].birthtimeMs) {	// refresh stats if empty
+		if (!clusterMemory.files_stats[fullpath].birthtimeMs || dataLengthWritten !== undefined) {
 			const stats = await fspromises.stat(fullpath), oldstats = clusterMemory.files_stats[fullpath];
-			clusterMemory.files_stats[fullpath] = {...stats, ...oldstats, disk_size: stats.size};	
+        	clusterMemory.files_stats[fullpath] = {...oldstats, ...stats, disk_size: stats.size};
 		}
 		await fspromises.writeFile(metaPath, JSON.stringify(clusterMemory.files_stats[fullpath]));
 		if (dataLengthWritten) clusterMemory.files_stats[fullpath].byteswritten = 0; 	// we updated due to a write and have finished uploading

--- a/frontend/apps/xbin/components/file-manager/file-manager.mjs
+++ b/frontend/apps/xbin/components/file-manager/file-manager.mjs
@@ -169,8 +169,8 @@ function handleClick(element, path, isDirectory, fromClickEvent, nomenu, clickEv
 function _fileListingEntrySelected(containedElement, stats) {
    const informationbox = file_manager.getShadowRootByContainedElement(containedElement).querySelector("div#informationbox");
    if (stats.size) stats.sizeLocale = parseInt(stats.size).toLocaleString(); 
-   if (stats.birthtime) stats.birthTimestampLocale = new Date(stats.birthtime).toLocaleString(); 
-   if (stats.mtime) stats.modifiedTimestampLocale = new Date(stats.mtime).toLocaleString(); 
+   if (stats.birthtimeMs) stats.birthTimestampLocale = new Date(stats.birthtimeMs).toLocaleString(); 
+   if (stats.mtimeMs) stats.modifiedTimestampLocale = new Date(stats.mtimeMs).toLocaleString(); 
    const arrayForBreadcrumbs = selectedPath.trim().replace(/^\/+/, "").split("/").slice(0, -1); arrayForBreadcrumbs.unshift("Home");
    stats.path = selectedPath; stats.pathBreadcrumbs = arrayForBreadcrumbs.join(" > "); 
    if (!stats.name) stats.name = containedElement.innerText;
@@ -438,6 +438,7 @@ async function editFileLoadData(element) {
       const resp = await apiman.rest(API_OPERATEFILE(), "POST", _addExtraInfo({path: selectedPath, op: "write", 
          data: result.filecontents}, element), true);
       if (!resp.result) _showErrordialog();
+      else router.reload(!ENCODE_URL, false);
    }); else _showErrordialog();
 }
 


### PR DESCRIPTION
**Root cause:**

- The Get Info popup was reading birthtime / mtime, while the serialized file metadata contains birthtimeMs / mtimeMs.
- In updateFileStats(), modified metadata was not being refreshed correctly after file updates because stale stats could override fresh filesystem stats.
- The file listing was not refreshed after inline save, so Get Info could continue showing stale metadata.

**Fix:**

- Updated the frontend to use birthtimeMs / mtimeMs.
- Corrected metadata refresh logic in updateFileStats() so fresh stats are retained after writes/updates.
- Reloaded the file listing after inline edit/save so Get Info reflects the latest values.

**Previous:**
<img width="745" height="767" alt="Screenshot from 2026-03-27 15-57-35" src="https://github.com/user-attachments/assets/4d797a3a-57a7-4829-9732-ecc86f1aab49" />

**After Fix:**
<img width="745" height="767" alt="Screenshot from 2026-03-27 15-57-08" src="https://github.com/user-attachments/assets/a16c78dd-1488-4482-8892-72355b99ecbc" />
